### PR TITLE
Enable vectorizer in gcc on s390x

### DIFF
--- a/cmake/compilation-flags.cmake
+++ b/cmake/compilation-flags.cmake
@@ -13,7 +13,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wwrite-strings -Wformat-security -Wcast-qua
 if(S390X)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=z14 -mvx -mzvector")
     if (NOT CLANG)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mbranch-cost=3")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mbranch-cost=3 -ftree-loop-vectorize -ftree-vectorize")
     endif()
 elseif(X86_64)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native -mno-red-zone")


### PR DESCRIPTION
... since it improves performance. Note that clang/LLVM has its vectorizers enabled by default.

Measuring performance on z14, I observe some improvement in all variants, with the most pronounced improvement in scalar radix-4 (~6%) and radix-4-vmsl (~6%) (both from N=14).
