### PR TITLE
Supporting aligned and unaligned benchmarks.

### DIFF
--- a/include/internal/avx512.h
+++ b/include/internal/avx512.h
@@ -25,6 +25,7 @@ EXTERNC_BEGIN
 #define SETR(a, b, c, d, e, f, g, h) \
   _mm512_setr_epi64((a), (b), (c), (d), (e), (f), (g), (h))
 #define LOAD(mem)       _mm512_loadu_epi64((mem))
+#define LOADA(mem)      _mm512_load_epi64((mem))
 #define STORE(mem, reg) _mm512_storeu_epi64((mem), (reg))
 
 #define GATHER(idx, mem, scale) _mm512_i64gather_epi64((idx), (mem), (scale))

--- a/include/internal/defs.h
+++ b/include/internal/defs.h
@@ -90,3 +90,5 @@
 #  define LOOP_UNROLL_4
 #  define LOOP_UNROLL_8
 #endif
+
+#define ALIGN(n) __attribute__((aligned(n)))

--- a/include/internal/pre_compute.h
+++ b/include/internal/pre_compute.h
@@ -211,6 +211,9 @@ static inline void expand_w_r4_avx512_ifma(uint64_t       w_expanded[],
     w_expanded[new_w_idx++] = q - ((w[w_idx + 1] * w[k + 3]) % q);
   }
 
+  // Align on an 8-qw boundary
+  new_w_idx = ((new_w_idx >> 3) << 3) + 8;
+
   // FWD1
   for(w_idx = (N >> 2); w_idx < (N >> 1); w_idx += 8) {
     // W1
@@ -272,6 +275,9 @@ static inline void expand_w_r4r2_avx512_ifma(uint64_t       w_expanded[],
     }
     w_idx = 4 * m;
   }
+
+  // Align on an 8-qw boundary
+  new_w_idx = ((new_w_idx >> 3) << 3) + 8;
 
   if(HAS_AN_EVEN_POWER(N)) {
     // FWD8 in radix2

--- a/src/ntt_r2_16_avx512_ifma.c
+++ b/src/ntt_r2_16_avx512_ifma.c
@@ -17,9 +17,9 @@ static inline void fwd16_r2(uint64_t *      a,
     const uint64_t      w_idx3 = w_idx2 + (8 * m);
     const uint64_t      w_idx4 = w_idx2 + (16 * m);
     const mul_op_m512_t w1     = {SET1(w[i]), SET1(w_con[i])};
-    const mul_op_m512_t w2     = {LOAD(&w[w_idx2]), LOAD(&w_con[w_idx2])};
-    const mul_op_m512_t w3     = {LOAD(&w[w_idx3]), LOAD(&w_con[w_idx3])};
-    const mul_op_m512_t w4     = {LOAD(&w[w_idx4]), LOAD(&w_con[w_idx4])};
+    const mul_op_m512_t w2     = {LOADA(&w[w_idx2]), LOADA(&w_con[w_idx2])};
+    const mul_op_m512_t w3     = {LOADA(&w[w_idx3]), LOADA(&w_con[w_idx3])};
+    const mul_op_m512_t w4     = {LOADA(&w[w_idx4]), LOADA(&w_con[w_idx4])};
 
     __m512i X = LOAD(&a[16 * i]);
     __m512i Y = LOAD(&a[16 * i + 8]);

--- a/src/ntt_r4r2_avx512_ifma.c
+++ b/src/ntt_r4r2_avx512_ifma.c
@@ -53,9 +53,9 @@ static inline void fwd8_r2(uint64_t *      a,
     const uint64_t      w_idx2 = (8 * i);
     const uint64_t      w_idx3 = w_idx2 + (8 * m);
     const uint64_t      w_idx4 = w_idx2 + (16 * m);
-    const mul_op_m512_t w2     = {LOAD(&w[w_idx2]), LOAD(&w_con[w_idx2])};
-    const mul_op_m512_t w3     = {LOAD(&w[w_idx3]), LOAD(&w_con[w_idx3])};
-    const mul_op_m512_t w4     = {LOAD(&w[w_idx4]), LOAD(&w_con[w_idx4])};
+    const mul_op_m512_t w2     = {LOADA(&w[w_idx2]), LOADA(&w_con[w_idx2])};
+    const mul_op_m512_t w3     = {LOADA(&w[w_idx3]), LOADA(&w_con[w_idx3])};
+    const mul_op_m512_t w4     = {LOADA(&w[w_idx4]), LOADA(&w_con[w_idx4])};
 
     // Radix-4 butterfly leaves values in [0, 8q)
     __m512i X =
@@ -82,9 +82,9 @@ static inline void fwd16_r2(uint64_t *      a,
     const uint64_t      w_idx3 = w_idx2 + (8 * m);
     const uint64_t      w_idx4 = w_idx2 + (16 * m);
     const mul_op_m512_t w1     = {SET1(w[i]), SET1(w_con[i])};
-    const mul_op_m512_t w2     = {LOAD(&w[w_idx2]), LOAD(&w_con[w_idx2])};
-    const mul_op_m512_t w3     = {LOAD(&w[w_idx3]), LOAD(&w_con[w_idx3])};
-    const mul_op_m512_t w4     = {LOAD(&w[w_idx4]), LOAD(&w_con[w_idx4])};
+    const mul_op_m512_t w2     = {LOADA(&w[w_idx2]), LOADA(&w_con[w_idx2])};
+    const mul_op_m512_t w3     = {LOADA(&w[w_idx3]), LOADA(&w_con[w_idx3])};
+    const mul_op_m512_t w4     = {LOADA(&w[w_idx4]), LOADA(&w_con[w_idx4])};
 
     // Radix-4 butterfly leaves values in [0, 8q)
     __m512i X =
@@ -159,6 +159,9 @@ void fwd_ntt_r4r2_avx512_ifma_lazy(uint64_t       a[],
     }
     t >>= 2;
   }
+
+  // Align on an 8-qw boundary
+  idx = ((idx >> 3) << 3) + 8;
 
   if(HAS_AN_EVEN_POWER(N)) {
     fwd16_r2(a, m, &w[idx], &w_con[idx], q);

--- a/src/ntt_radix4_avx512_ifma.c
+++ b/src/ntt_radix4_avx512_ifma.c
@@ -10,17 +10,17 @@ static inline void collect_roots_fwd1(mul_op_m512_t  w1[5],
                                       const uint64_t w_con[],
                                       size_t *       idx)
 {
-  w1[0].op = LOAD(&w[*idx]);
-  w1[1].op = LOAD(&w[*idx + 8]);
-  w1[2].op = LOAD(&w[*idx + 16]);
-  w1[3].op = LOAD(&w[*idx + 24]);
-  w1[4].op = LOAD(&w[*idx + 32]);
+  w1[0].op = LOADA(&w[*idx]);
+  w1[1].op = LOADA(&w[*idx + 8]);
+  w1[2].op = LOADA(&w[*idx + 16]);
+  w1[3].op = LOADA(&w[*idx + 24]);
+  w1[4].op = LOADA(&w[*idx + 32]);
 
-  w1[0].con = LOAD(&w_con[*idx]);
-  w1[1].con = LOAD(&w_con[*idx + 8]);
-  w1[2].con = LOAD(&w_con[*idx + 16]);
-  w1[3].con = LOAD(&w_con[*idx + 24]);
-  w1[4].con = LOAD(&w_con[*idx + 32]);
+  w1[0].con = LOADA(&w_con[*idx]);
+  w1[1].con = LOADA(&w_con[*idx + 8]);
+  w1[2].con = LOADA(&w_con[*idx + 16]);
+  w1[3].con = LOADA(&w_con[*idx + 24]);
+  w1[4].con = LOADA(&w_con[*idx + 32]);
 
   *idx += 5 * 8;
 }
@@ -179,6 +179,9 @@ void fwd_ntt_radix4_avx512_ifma_lazy(uint64_t       a[],
         fwd4(&a[4 * 4 * j], roots, q);
       }
     } else {
+      // Align on an 8-qw boundary
+      idx = ((idx >> 3) << 3) + 8;
+
       LOOP_UNROLL_4
       for(size_t j = 0; j < m; j += 8) {
         collect_roots_fwd1(roots, w, w_con, &idx);

--- a/src/ntt_radix4_avx512_ifma_unordered.c
+++ b/src/ntt_radix4_avx512_ifma_unordered.c
@@ -5,39 +5,22 @@
 
 #  include "ntt_avx512_ifma.h"
 
-/******************************************************/
-
-/******************************************************/
-
-// static inline void print(UNUSED const uint64_t *values, UNUSED const size_t n)
-// {
-// #ifdef DEBUG
-//   for(size_t i = 0; i < n; i++) {
-//     printf("%lx ", values[i] & AVX512_IFMA_WORD_SIZE_MASK);
-//   }
-//   printf("\n");
-// #endif
-// }
-
-/******************************************************/
-/******************************************************/
-
 static inline void collect_roots_fwd1(mul_op_m512_t  w1[5],
                                       const uint64_t w[],
                                       const uint64_t w_con[],
                                       size_t *       idx)
 {
-  w1[0].op = LOAD(&w[*idx]);
-  w1[1].op = LOAD(&w[*idx + 8]);
-  w1[2].op = LOAD(&w[*idx + 16]);
-  w1[3].op = LOAD(&w[*idx + 24]);
-  w1[4].op = LOAD(&w[*idx + 32]);
+  w1[0].op = LOADA(&w[*idx]);
+  w1[1].op = LOADA(&w[*idx + 8]);
+  w1[2].op = LOADA(&w[*idx + 16]);
+  w1[3].op = LOADA(&w[*idx + 24]);
+  w1[4].op = LOADA(&w[*idx + 32]);
 
-  w1[0].con = LOAD(&w_con[*idx]);
-  w1[1].con = LOAD(&w_con[*idx + 8]);
-  w1[2].con = LOAD(&w_con[*idx + 16]);
-  w1[3].con = LOAD(&w_con[*idx + 24]);
-  w1[4].con = LOAD(&w_con[*idx + 32]);
+  w1[0].con = LOADA(&w_con[*idx]);
+  w1[1].con = LOADA(&w_con[*idx + 8]);
+  w1[2].con = LOADA(&w_con[*idx + 16]);
+  w1[3].con = LOADA(&w_con[*idx + 24]);
+  w1[4].con = LOADA(&w_con[*idx + 32]);
 
   *idx += 5 * 8;
 }
@@ -191,6 +174,9 @@ void fwd_ntt_radix4_avx512_ifma_lazy_unordered(uint64_t       a[],
         fwd4(&a[4 * 4 * j], roots, q);
       }
     } else {
+      // Align on an 8-qw boundary
+      idx = ((idx >> 3) << 3) + 8;
+
       for(size_t j = 0; j < m;) {
         LOOP_UNROLL_4
         for(size_t k = 0; k < 4; k += 1, j += 8) {

--- a/tests/main.c
+++ b/tests/main.c
@@ -16,11 +16,19 @@ int main(UNUSED int argc, UNUSED char *argv[])
     return SUCCESS;
   }
 
+  printf("\n\nTesting forward NTT with unaligned inputs\n\n");
   report_test_fwd_perf_headers();
   for(size_t i = 0; i < NUM_OF_TEST_CASES; i++) {
-    test_fwd_perf(&tests[i]);
+    test_unaligned_fwd_perf(&tests[i]);
   }
 
+  printf("Testing forward NTT with aligned inputs\n\n");
+  report_test_fwd_perf_headers();
+  for(size_t i = 0; i < NUM_OF_TEST_CASES; i++) {
+    test_aligned_fwd_perf(&tests[i]);
+  }
+
+  printf("Testing inverse NTT with unaligned inputs\n\n");
   report_test_inv_perf_headers();
   for(size_t i = 0; i < NUM_OF_TEST_CASES; i++) {
     test_inv_perf(&tests[i]);

--- a/tests/test_correctness.c
+++ b/tests/test_correctness.c
@@ -26,11 +26,11 @@ static inline int test_radix2_scalar(const test_case_t *t, uint64_t a_orig[])
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_ref_harvey\n");
-  fwd_ntt_ref_harvey(a, t->n, t->q, t->w_powers, t->w_powers_con);
+  fwd_ntt_ref_harvey(a, t->n, t->q, t->w_powers.ptr, t->w_powers_con.ptr);
 
   printf("Running inv_ntt_ref_harvey\n");
-  inv_ntt_ref_harvey(a, t->n, t->q, t->n_inv, WORD_SIZE, t->w_inv_powers,
-                     t->w_inv_powers_con);
+  inv_ntt_ref_harvey(a, t->n, t->q, t->n_inv, WORD_SIZE, t->w_inv_powers.ptr,
+                     t->w_inv_powers_con.ptr);
 
   GUARD_MSG(memcmp(a_orig, a, sizeof(a)), "Bad results after radix-2 inv\n");
 
@@ -48,7 +48,7 @@ static inline int test_radix2_scalar_dbl(const test_case_t *t,
   memcpy(b, b_orig, sizeof(a));
 
   printf("Running fwd_ntt_ref_harvey_dbl\n");
-  fwd_ntt_ref_harvey_dbl(a, b, t->n, t->q, t->w_powers, t->w_powers_con);
+  fwd_ntt_ref_harvey_dbl(a, b, t->n, t->q, t->w_powers.ptr, t->w_powers_con.ptr);
 
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after radix-2 scalar double for a\n");
@@ -65,13 +65,13 @@ test_radix2_scalar_seal(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_seal\n");
-  fwd_ntt_seal(a, t->n, t->q, t->w_powers, t->w_powers_con);
+  fwd_ntt_seal(a, t->n, t->q, t->w_powers.ptr, t->w_powers_con.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after radix-2 SEAL fwd implementation\n");
 
   printf("Running inv_ntt_seal\n");
-  inv_ntt_seal(a, t->n, t->q, t->n_inv.op, t->n_inv.con, t->w_inv_powers,
-               t->w_inv_powers_con);
+  inv_ntt_seal(a, t->n, t->q, t->n_inv.op, t->n_inv.con, t->w_inv_powers.ptr,
+               t->w_inv_powers_con.ptr);
   GUARD_MSG(memcmp(a_orig, a, sizeof(a)),
             "Bad results after radix-2 SEAL inv implementation\n");
 
@@ -85,12 +85,12 @@ test_radix4_scalar(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[])
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_radix4\n");
-  fwd_ntt_radix4(a, t->n, t->q, t->w_powers_r4, t->w_powers_con_r4);
+  fwd_ntt_radix4(a, t->n, t->q, t->w_powers_r4.ptr, t->w_powers_con_r4.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)), "Bad results after radix-4 fwd\n");
 
   printf("Running inv_ntt_radix4\n");
-  inv_ntt_radix4(a, t->n, t->q, t->n_inv, t->w_inv_powers_r4,
-                 t->w_inv_powers_con_r4);
+  inv_ntt_radix4(a, t->n, t->q, t->n_inv, t->w_inv_powers_r4.ptr,
+                 t->w_inv_powers_con_r4.ptr);
 
   GUARD_MSG(memcmp(a_orig, a, sizeof(a)), "Bad results after radix-4 inv\n");
 
@@ -104,15 +104,9 @@ test_radix4x4_scalar(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[])
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_radix4x4\n");
-  fwd_ntt_radix4x4(a, t->n, t->q, t->w_powers_r4, t->w_powers_con_r4);
+  fwd_ntt_radix4x4(a, t->n, t->q, t->w_powers_r4.ptr, t->w_powers_con_r4.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)), "Bad results after radix-4x4 fwd\n");
-  /*
-    printf("Running inv_ntt_radix4\n");
-    inv_ntt_radix4(a, t->n, t->q, t->n_inv, t->w_inv_powers_r4,
-                   t->w_inv_powers_con_r4);
 
-    GUARD_MSG(memcmp(a_orig, a, sizeof(a)), "Bad results after radix-4 inv\n");
-  */
   return SUCCESS;
 }
 
@@ -124,14 +118,14 @@ test_radix4_intrinsic(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[])
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_radix4_intrinsic\n");
-  fwd_ntt_radix4_intrinsic(a, t->n, t->q, t->w_powers_r4,
-                           t->w_powers_con_r4_vmsl);
+  fwd_ntt_radix4_intrinsic(a, t->n, t->q, t->w_powers_r4.ptr,
+                           t->w_powers_con_r4_vmsl.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after radix-4 with intrinsic fwd\n");
 
   printf("Running inv_ntt_radix4_intrinsic\n");
-  inv_ntt_radix4_intrinsic(a, t->n, t->q, t->n_inv_vmsl, t->w_inv_powers_r4,
-                           t->w_inv_powers_con_r4_vmsl);
+  inv_ntt_radix4_intrinsic(a, t->n, t->q, t->n_inv_vmsl, t->w_inv_powers_r4.ptr,
+                           t->w_inv_powers_con_r4_vmsl.ptr);
 
   GUARD_MSG(memcmp(a_orig, a, sizeof(a)),
             "Bad results after radix-4 inv with intrinsic\n");
@@ -150,8 +144,8 @@ static inline int test_radix4_intrinsic_dbl(const test_case_t *t,
   memcpy(b, b_orig, sizeof(a));
 
   printf("Running fwd_ntt_ref_harvey_dbl\n");
-  fwd_ntt_radix4_intrinsic_dbl(a, b, t->n, t->q, t->w_powers_r4,
-                               t->w_powers_con_r4_vmsl);
+  fwd_ntt_radix4_intrinsic_dbl(a, b, t->n, t->q, t->w_powers_r4.ptr,
+                               t->w_powers_con_r4_vmsl.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after radix-2 scalar double for a\n");
   GUARD_MSG(memcmp(a_ntt, b, sizeof(b)),
@@ -174,7 +168,8 @@ test_radix2_hexl(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[])
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_radix2_hexl\n");
-  fwd_ntt_radix2_hexl(a, t->n, t->q, t->w_powers_hexl, t->w_powers_con_hexl);
+  fwd_ntt_radix2_hexl(a, t->n, t->q, t->w_powers_hexl.ptr,
+                      t->w_powers_con_hexl.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after HEXL radix-2 with AVX512-IFMA intrinsic fwd\n");
 
@@ -225,16 +220,16 @@ test_radix4_avx512_ifma(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[
   memcpy(a, a_orig, sizeof(a));
 
   printf("Running fwd_ntt_radix4_avx512_ifma\n");
-  fwd_ntt_radix4_avx512_ifma(a, t->n, t->q, t->w_powers_r4_avx512_ifma,
-                             t->w_powers_con_r4_avx512_ifma);
+  fwd_ntt_radix4_avx512_ifma(a, t->n, t->q, t->w_powers_r4_avx512_ifma.ptr,
+                             t->w_powers_con_r4_avx512_ifma.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after radix-4 with AVX512-IFMA intrinsic fwd\n");
 
   memcpy(a, a_orig, sizeof(a));
   printf("Running fwd_ntt_radix4_avx512_ifma_unordered\n");
-  fwd_ntt_radix4_avx512_ifma_unordered(a, t->n, t->q,
-                                       t->w_powers_r4_avx512_ifma_unordered,
-                                       t->w_powers_con_r4_avx512_ifma_unordered);
+  fwd_ntt_radix4_avx512_ifma_unordered(
+    a, t->n, t->q, t->w_powers_r4_avx512_ifma_unordered.ptr,
+    t->w_powers_con_r4_avx512_ifma_unordered.ptr);
   fix_a_order(a, t->n);
   GUARD_MSG(
     memcmp(a_ntt, a, sizeof(a)),
@@ -242,15 +237,15 @@ test_radix4_avx512_ifma(const test_case_t *t, uint64_t a_orig[], uint64_t a_ntt[
 
   memcpy(a, a_orig, sizeof(a));
   printf("Running fwd_ntt_r4r2_avx512_ifma\n");
-  fwd_ntt_r4r2_avx512_ifma(a, t->n, t->q, t->w_powers_r4r2_avx512_ifma,
-                           t->w_powers_con_r4r2_avx512_ifma);
+  fwd_ntt_r4r2_avx512_ifma(a, t->n, t->q, t->w_powers_r4r2_avx512_ifma.ptr,
+                           t->w_powers_con_r4r2_avx512_ifma.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after r4r2 with AVX512-IFMA intrinsic fwd\n");
 
   memcpy(a, a_orig, sizeof(a));
   printf("Running fwd_ntt_r2_16_avx512_ifma\n");
-  fwd_ntt_r2_16_avx512_ifma(a, t->n, t->q, t->w_powers_r2_16_avx512_ifma,
-                            t->w_powers_con_r2_16_avx512_ifma);
+  fwd_ntt_r2_16_avx512_ifma(a, t->n, t->q, t->w_powers_r2_16_avx512_ifma.ptr,
+                            t->w_powers_con_r2_16_avx512_ifma.ptr);
   GUARD_MSG(memcmp(a_ntt, a, sizeof(a)),
             "Bad results after r2_16 with AVX512-IFMA intrinsic fwd\n");
 
@@ -270,7 +265,7 @@ int test_correctness(const test_case_t *t)
   memcpy(b, a, sizeof(a));
 
   // Prepare a_ntt = NTT(a)
-  fwd_ntt_ref_harvey(a_cpy, t->n, t->q, t->w_powers, t->w_powers_con);
+  fwd_ntt_ref_harvey(a_cpy, t->n, t->q, t->w_powers.ptr, t->w_powers_con.ptr);
   memcpy(a_ntt, a_cpy, sizeof(a_cpy));
 
   GUARD(test_radix2_scalar(t, a));

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -28,7 +28,8 @@ typedef enum
 void report_test_fwd_perf_headers(void);
 void report_test_inv_perf_headers(void);
 
-void test_fwd_perf(const test_case_t *t);
+void test_aligned_fwd_perf(const test_case_t *t);
+void test_unaligned_fwd_perf(const test_case_t *t);
 void test_inv_perf(const test_case_t *t);
 
 void test_fwd_single_case(const test_case_t *t, func_num_t func_num);


### PR DESCRIPTION
This pull request enables benchmarks of aligned and unaligned inputs. 
In addition, based on a suggestion by @fboemer it aligns all twiddles on 8-qw boundaries.